### PR TITLE
remove angular.js script tag from assets/index.html

### DIFF
--- a/client/assets/index.html
+++ b/client/assets/index.html
@@ -2,21 +2,21 @@
 <html ng-app="RowdyMermaid-site">
 
 <head>
-    <title>Rowdy Mermaid</title>
-    <link rel='stylesheet' href='styles/main.css'>
-    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
-    <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="theme-color" content="#ffffff">
-    <base href="/">
+  <title>Rowdy Mermaid</title>
+  <link rel='stylesheet' href='styles/main.css'>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+  <meta name="msapplication-TileColor" content="#ffffff">
+  <meta name="theme-color" content="#ffffff">
+  <base href="/">
 </head>
+
 <body>
-    <ui-view>
-    </ui-view>
-    <script type="text/javascript" src="scripts/vendor.js"></script>
-    <script type="text/javascript" src="scripts/bundle.js"></script>
-    <script src="angular.js"></script>
-    <script src="http://maps.google.com/maps/api/js?sensor=true&key=API_KEY"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gmaps.js/0.4.25/gmaps.js"></script>
+  <ui-view>
+  </ui-view>
+  <script type="text/javascript" src="scripts/vendor.js"></script>
+  <script type="text/javascript" src="scripts/bundle.js"></script>
+  <script src="http://maps.google.com/maps/api/js?sensor=true&key=API_KEY"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gmaps.js/0.4.25/gmaps.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
On merge #137 `angular.js` script tags were added to index.html causing the following error: ```Uncaught SyntaxError: Unexpected token <```

This script tag isn't needed since angular.js is brought in through yarn and injected via the gulpfile.

Pretty sure this was the cause of the error. After removing, the error is no longer appearing.